### PR TITLE
Simplifying github action with official GraalVM action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [windows-latest]
     steps:
     - uses: actions/checkout@v1
     - uses: graalvm/setup-graalvm@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Rename the artifact to OS-unique name
       shell: bash
       run: |
-        value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
+        value=`cp build/native-image/checksum build/native-image/checksum-${{ matrix.os }}`
     - name: Publish artifact
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,32 +29,32 @@ jobs:
         name: checksum-${{ matrix.os }}
         path: build/graal
 
-  build-windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2016, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          version: '22.3.0'
-          java-version: '11'
-          components: 'native-image'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: java -version
-      - name: Build with Gradle
-        shell: cmd
-        run: |
-          ./gradlew build
-      - name: Rename the artifact to OS-unique name
-        shell: bash
-        run: |
-          value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
-      - name: Publish artifact
-        uses: actions/upload-artifact@master
-        with:
-          name: checksum-${{ matrix.os }}.exe
-          path: build/graal
+#  build-windows:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [windows-2016, windows-latest]
+#
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: graalvm/setup-graalvm@v1
+#        with:
+#          version: '22.3.0'
+#          java-version: '11'
+#          components: 'native-image'
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#      - run: java -version
+#      - name: Build with Gradle
+#        shell: cmd
+#        run: |
+#          ./gradlew build
+#      - name: Rename the artifact to OS-unique name
+#        shell: bash
+#        run: |
+#          value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
+#      - name: Publish artifact
+#        uses: actions/upload-artifact@master
+#        with:
+#          name: checksum-${{ matrix.os }}.exe
+#          path: build/graal

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,8 +18,14 @@ jobs:
     - run: java -version
     - name: Build with Gradle
       run: ./gradlew build
-    - name: Rename the artifact to OS-unique name
+    - name: Rename the artifact to OS-unique name on Windows
       shell: bash
+      if: matrix.os == 'windows-latest'
+      run: |
+        value=`cp build\graal\checksum build\graal\checksum-${{ matrix.os }}`
+    - name: Rename the artifact to OS-unique name on Ubuntu and MacOS
+      shell: bash
+      if: matrix.os != 'windows-latest'
       run: |
         value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
     - name: Publish artifact

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,8 +1,6 @@
 name: Java CI
 
 on: [push]
-permissions:
-  contents: write
 jobs:
   build-ubuntu-mac:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: graalvm/setup-graalvm@v1
       with:
-        version: '19.3.0.2'
+        version: '22.3.0'
         java-version: '11'
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - uses: graalvm/setup-graalvm@v1
@@ -27,34 +27,4 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: checksum-${{ matrix.os }}
-        path: build/graal
-
-#  build-windows:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [windows-2016, windows-latest]
-#
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: graalvm/setup-graalvm@v1
-#        with:
-#          version: '22.3.0'
-#          java-version: '11'
-#          components: 'native-image'
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#      - run: java -version
-#      - name: Build with Gradle
-#        shell: cmd
-#        run: |
-#          ./gradlew build
-#      - name: Rename the artifact to OS-unique name
-#        shell: bash
-#        run: |
-#          value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
-#      - name: Publish artifact
-#        uses: actions/upload-artifact@master
-#        with:
-#          name: checksum-${{ matrix.os }}.exe
-#          path: build/graal
+        path: build/native-image

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,21 +1,23 @@
 name: Java CI
 
 on: [push]
-
+permissions:
+  contents: write
 jobs:
   build-ubuntu-mac:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
-
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
-    - uses: DeLaGuardo/setup-graalvm@2.0
+    - uses: graalvm/setup-graalvm@v1
       with:
-        graalvm-version: '19.3.0.2.java11'
+        version: '19.3.0.2'
+        java-version: '11'
+        components: 'native-image'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - run: java -version
-    - run: gu install native-image
     - name: Build with Gradle
       run: ./gradlew build
     - name: Rename the artifact to OS-unique name
@@ -27,34 +29,3 @@ jobs:
       with:
         name: checksum-${{ matrix.os }}
         path: build/graal
-
-  build-windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2016, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v1
-      - uses: DeLaGuardo/setup-graalvm@2.0
-        with:
-          graalvm-version: '19.3.0.2.java11'
-      - run: java -version
-      - name: Set up Visual C Build Tools Workload for Visual Studio 2017 Build Tools
-        run: |
-          choco install visualstudio2017-workload-vctools
-      - name: set env variables and run the Gradle build
-        shell: cmd
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          ./gradlew build
-      - name: Rename the artifact to OS-unique name
-        shell: bash
-        run: |
-          value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
-      - name: Publish artifact
-        uses: actions/upload-artifact@master
-        with:
-          name: checksum-${{ matrix.os }}.exe
-          path: build/graal

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,11 +2,12 @@ name: Java CI
 
 on: [push]
 jobs:
+
   build-ubuntu-mac:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v1
     - uses: graalvm/setup-graalvm@v1
@@ -18,14 +19,8 @@ jobs:
     - run: java -version
     - name: Build with Gradle
       run: ./gradlew build
-    - name: Rename the artifact to OS-unique name on Windows
+    - name: Rename the artifact to OS-unique name
       shell: bash
-      if: matrix.os == 'windows-latest'
-      run: |
-        value=`cp build\graal\checksum build\graal\checksum-${{ matrix.os }}`
-    - name: Rename the artifact to OS-unique name on Ubuntu and MacOS
-      shell: bash
-      if: matrix.os != 'windows-latest'
       run: |
         value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
     - name: Publish artifact
@@ -33,3 +28,33 @@ jobs:
       with:
         name: checksum-${{ matrix.os }}
         path: build/graal
+
+  build-windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2016, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: '22.3.0'
+          java-version: '11'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: java -version
+      - name: Build with Gradle
+        shell: cmd
+        run: |
+          ./gradlew build
+      - name: Rename the artifact to OS-unique name
+        shell: bash
+        run: |
+          value=`cp build/graal/checksum build/graal/checksum-${{ matrix.os }}`
+      - name: Publish artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: checksum-${{ matrix.os }}.exe
+          path: build/graal


### PR DESCRIPTION
**Changes:**

This resolves one of the points discussed here : https://github.com/remkop/picocli/issues/2077

Basically this now simplifies the Github action and also uses official GraalVM action which is feature rich and also better supported.

**Testing:** 

This was tested in the forked repository and successful run can be found [here](https://github.com/bhavikp19/picocli-native-image-demo/actions/runs/5776113035).

**Future work:** 

As noted [here ](https://github.com/remkop/picocli-native-image-demo/issues) we should look at removing the existing gradle plusing in build scripts and replace that with official GraalVM gradle plugin